### PR TITLE
Add the ability to invoke effectors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 brooklyn-cli
+.idea
+*.iml
+temp_test.go

--- a/api/entity_effectors/effectors.go
+++ b/api/entity_effectors/effectors.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 	"github.com/brooklyncentral/brooklyn-cli/models"
 	"github.com/brooklyncentral/brooklyn-cli/net"
+	"net/url"
+	"errors"
+	"strings"
+	"bytes"
+	"strconv"
 )
 
 func EffectorList(network *net.Network, application, entity string) []models.EffectorSummary {
-	url := fmt.Sprintf("/v1/applications/%s/entities/%s/effectors", application, entity)
-	body, err := network.SendGetRequest(url)
+	path := fmt.Sprintf("/v1/applications/%s/entities/%s/effectors", application, entity)
+	body, err := network.SendGetRequest(path)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -22,11 +27,21 @@ func EffectorList(network *net.Network, application, entity string) []models.Eff
 	return effectorList
 }
 
-func TriggerEffector(network *net.Network, application, entity, effector string) string {
-	url := fmt.Sprintf("/v1/applications/%s/entities/%s/effectors/%s", application, entity, effector)
-	body, err := network.SendEmptyPostRequest(url)
-	if err != nil {
-		fmt.Println(err)
+func TriggerEffector(network *net.Network, application, entity, effector string, params []string, args []string) (string, error) {
+	if len(params) != len(args) {
+		return "", errors.New(strings.Join([]string{"Parameters not supplied:", strings.Join(params, ", ")}, " "))
 	}
-	return string(body)
+	path := fmt.Sprintf("/v1/applications/%s/entities/%s/effectors/%s", application, entity, effector)
+	data := url.Values{}
+	for i := range params {
+		data.Set(params[i], args[i])
+	}
+	req := network.NewPostRequest(path, bytes.NewBufferString(data.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+	body, err := network.SendRequest(req)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
 }

--- a/commands/effectors.go
+++ b/commands/effectors.go
@@ -4,9 +4,13 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/brooklyncentral/brooklyn-cli/api/entity_effectors"
 	"github.com/brooklyncentral/brooklyn-cli/command_metadata"
+	"github.com/brooklyncentral/brooklyn-cli/models"
 	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/terminal"
 	"strings"
+	"errors"
+	"fmt"
+	"os"
 )
 
 type Effectors struct {
@@ -23,12 +27,23 @@ func (cmd *Effectors) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "effectors",
 		Description: "Show the list of effectors for an application and entity",
-		Usage:       "BROOKLYN_NAME effectors APPLICATION ENITITY",
+		Usage:       "BROOKLYN_NAME effectors APPLICATION ENTITY",
 		Flags:       []cli.Flag{},
 	}
 }
 
 func (cmd *Effectors) Run(c *cli.Context) {
+	if len(c.Args()) < 3 {
+		cmd.listEffectors(c)
+	} else {
+		err := cmd.invokeEffector(c)
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
+	}
+}
+
+func (cmd *Effectors) listEffectors(c *cli.Context) {
 	effectors := entity_effectors.EffectorList(cmd.network, c.Args()[0], c.Args()[1])
 	table := terminal.NewTable([]string{"Name", "Description", "Parameters"})
 	for _, effector := range effectors {
@@ -39,4 +54,49 @@ func (cmd *Effectors) Run(c *cli.Context) {
 		table.Add(effector.Name, effector.Description, strings.Join(parameters, ","))
 	}
 	table.Print()
+}
+
+func (cmd *Effectors) invokeEffector(c *cli.Context) error {
+	applicationId := c.Args().First()
+	entityId := c.Args()[1]
+	effectorName := c.Args()[2]
+	effectorArgs := c.Args()[3:]
+
+	// get the effector
+	effectors := entity_effectors.EffectorList(cmd.network, c.Args()[0], c.Args()[1])
+	effector, err := findEffector(effectorName, effectors)
+	if nil != err {
+		return err
+	}
+
+	// get its parameters and check we have an arg for each
+	parameters := make([]string, 0)
+	for _, parameter := range effector.Parameters {
+		parameters = append(parameters, parameter.Name)
+	}
+	if len(parameters) != len(effectorArgs) {
+		return parameterMisMatchError(parameters)
+	}
+
+	// invoke it
+	_, err = entity_effectors.TriggerEffector(cmd.network, applicationId, entityId, effectorName, parameters, effectorArgs)
+	return err
+}
+
+func parameterMisMatchError(parameters []string) error {
+	pnames := []string{}
+	for _, parm := range parameters {
+		pnames = append(pnames, parm)
+	}
+	pnameDesc := strings.Join(pnames, ", ")
+	return errors.New(strings.Join([]string{"Parameters not supplied: ", pnameDesc}, ""))
+}
+
+func findEffector(name string, effectors []models.EffectorSummary) (models.EffectorSummary, error) {
+	for _, effector := range effectors {
+		if effector.Name == name {
+			return effector, nil
+		}
+	}
+	return models.EffectorSummary{}, errors.New(strings.Join([]string{"Effector not found:", name}, " "))
 }


### PR DESCRIPTION
For a given effector, invoke it with

brooklyn-cli effectors APPID ENTITYID EFFECTORNAME [ params ]

where params is a sequence of values for the parameters of the effector, if any.

For example see the following sequence ("brooklyn-cli" has been aliased to "bk"):

$ bk applications
Id   Name   Status   Location
$
$
$ bk create myweb.yaml
response Status: 201 Created
...
$ bk applications
Id         Name             Status    Location
DRGUqnXs   My Web Cluster   RUNNING   fm7gDUks
$
$ bk entities DRGUqnXs
Id         Name     Type
dhwkYGGX   My Web   org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
TTHOUkbx   My DB    org.apache.brooklyn.entity.database.mysql.MySqlNode
$ bk sensors DRGUqnXs dhwkYGGX | grep webapp.deployedWars
$
webapp.deployedWars                                    Names of archives/contexts that are currently deployed
$ bk effectors DRGUqnXs dhwkYGGX | grep deploy
deploy           Deploys the given artifact, from a source URL, to a given deployment filename/context                                                                                                  url,targetName
...
$ bk effectors DRGUqnXs dhwkYGGX deploy https://tomcat.apache.org/tomcat-6.0-doc/appdev/sample/sample.war mysample
response Status: 202 Accepted
response Headers: map[Content-Length:[0] Set-Cookie:[JSESSIONID_BROOKLYNJLKc8Z=cwjdngii3o919cawdrezzajb;Path=/] Content-Type:[application/json] Vary:[Accept-Encoding] Pragma:[no-cache] Date:[Thu, 26 Nov 2015 22:22:22 GMT] Expires:[Thu, 01 Jan 1970 00:00:00 GMT 0] Cache-Control:[no-cache, no-store] Server:[Jetty(9.2.13.v20150730)]]
response Body:
$
$ bk sensors DRGUqnXs dhwkYGGX | grep webapp.deployedWars
webapp.deployedWars                                    Names of archives/contexts that are currently deployed                                                           ["/mysample"]
bk effectors DRGUqnXs DRGUqnXs stop
response Status: 202 Accepted
response Headers: map[Server:[Jetty(9.2.13.v20150730)] Set-Cookie:[JSESSIONID_BROOKLYNJLKc8Z=6ker7g8hfzmn1gj07i3znbq3l;Path=/] Expires:[Thu, 01 Jan 1970 00:00:00 GMT 0] Vary:[Accept-Encoding] Content-Length:[0] Date:[Thu, 26 Nov 2015 22:27:31 GMT] Content-Type:[application/json] Cache-Control:[no-cache, no-store] Pragma:[no-cache]]
response Body:
$
$ bk applications
Id   Name   Status   Location
$
