### PR TITLE
Add parameter checking for login command

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -1,15 +1,17 @@
 package commands
 
 import (
-	"github.com/codegangsta/cli"
+	"fmt"
 	"github.com/brooklyncentral/brooklyn-cli/command_metadata"
-	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/io"
+	"github.com/brooklyncentral/brooklyn-cli/net"
+	"github.com/codegangsta/cli"
+	"os"
 )
 
 type Login struct {
 	network *net.Network
-	config *io.Config
+	config  *io.Config
 }
 
 func NewLogin(network *net.Network, config *io.Config) (cmd *Login) {
@@ -23,16 +25,30 @@ func (cmd *Login) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "login",
 		Description: "Login to brooklyn",
-		Usage:       "BROOKLYN_NAME login URL USER PASSWORD",
+		Usage:       "BROOKLYN_NAME login URL [USER PASSWORD]",
 		Flags:       []cli.Flag{},
 	}
 }
 
 func (cmd *Login) Run(c *cli.Context) {
-	cmd.network.BrooklynUrl = c.Args()[0]
-	cmd.network.BrooklynUser = c.Args()[1]
-	cmd.network.BrooklynPass = c.Args()[2]
-	
+	defer func() {
+		if str := recover(); str != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", str)
+			os.Exit(1)
+		}
+	}()
+	if !c.Args().Present() {
+		panic("A URL must be provided as the first argument")
+	}
+
+	// If an argument was not supplied, it is set to empty string
+	cmd.network.BrooklynUrl = c.Args().Get(0)
+	cmd.network.BrooklynUser = c.Args().Get(1)
+	cmd.network.BrooklynPass = c.Args().Get(2)
+	if cmd.network.BrooklynUser != "" && cmd.network.BrooklynPass == "" {
+		panic("If a username is provided, a password must also be provided")
+	}
+
 	if cmd.config.Map == nil {
 		cmd.config.Map = make(map[string]interface{})
 	}
@@ -42,12 +58,12 @@ func (cmd *Login) Run(c *cli.Context) {
 		auth = make(map[string]interface{})
 		cmd.config.Map["auth"] = auth
 	}
-	
+
 	auth[cmd.network.BrooklynUrl] = map[string]string{
 		"username": cmd.network.BrooklynUser,
 		"password": cmd.network.BrooklynPass,
 	}
-	
+
 	cmd.config.Map["target"] = cmd.network.BrooklynUrl
 	cmd.config.Write()
 }


### PR DESCRIPTION
This change introduces parameter checking for the login command.
If the parameters are not as required, an error message is printed
to `STDERR` and the exit status is set to 1.

The checks performed are:
- Ensure that at least one parameter (the URL) is provided
- Ensure that a password is provided if the username is provided

This implementation makes use of panic and recover within the
`commands.(*Login).Run` function.  However, it may be better to use
a globally defined error reporting function to ensure consistency
of handling for all of the commands.
