### PR TITLE
Introduce a generic Exit/Error handler and use this for the login command

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -2,12 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"github.com/brooklyncentral/brooklyn-cli/api/version"
 	"github.com/brooklyncentral/brooklyn-cli/command_metadata"
+	"github.com/brooklyncentral/brooklyn-cli/error_handler"
 	"github.com/brooklyncentral/brooklyn-cli/io"
 	"github.com/brooklyncentral/brooklyn-cli/net"
+	"github.com/brooklyncentral/brooklyn-cli/scope"
 	"github.com/codegangsta/cli"
 	"os"
-	"github.com/brooklyncentral/brooklyn-cli/scope"
 )
 
 type Login struct {
@@ -32,14 +34,8 @@ func (cmd *Login) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
-	defer func() {
-		if str := recover(); str != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", str)
-			os.Exit(1)
-		}
-	}()
 	if !c.Args().Present() {
-		panic("A URL must be provided as the first argument")
+		error_handler.ErrorExit("A URL must be provided as the first argument",error_handler.CLIUsageErrorExitCode)
 	}
 
 	// If an argument was not supplied, it is set to empty string
@@ -47,7 +43,7 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 	cmd.network.BrooklynUser = c.Args().Get(1)
 	cmd.network.BrooklynPass = c.Args().Get(2)
 	if cmd.network.BrooklynUser != "" && cmd.network.BrooklynPass == "" {
-		panic("If a username is provided, a password must also be provided")
+		error_handler.ErrorExit("If a username is provided, a password must also be provided",error_handler.CLIUsageErrorExitCode)
 	}
 
 	if cmd.config.Map == nil {
@@ -67,4 +63,7 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 
 	cmd.config.Map["target"] = cmd.network.BrooklynUrl
 	cmd.config.Write()
+	
+	loginversion := version.Version(cmd.network)
+	fmt.Printf("Connected to Brooklyn version %s at %s\n",loginversion,cmd.network.BrooklynUrl)
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/scope"
 	"github.com/codegangsta/cli"
-	"os"
 )
 
 type Login struct {

--- a/error_handler/error.go
+++ b/error_handler/error.go
@@ -1,0 +1,28 @@
+package error_handler
+
+import (
+	"fmt"
+	"os"
+)
+
+const CLIUsageErrorExitCode int = 1
+const CliGenericErrorExitCode int = 2
+const CLITrapErrorCode int = 3
+
+func ErrorExit(errorvalue interface{}, errorcode ...int) () {
+	switch errorvalue.(type){
+	case error:
+		fmt.Fprintln(os.Stderr, errorvalue)
+	case string:
+		fmt.Fprintln(os.Stderr, errorvalue)
+	case nil:
+		fmt.Fprintln(os.Stderr, "No error message provided")
+	default:
+		fmt.Fprintln(os.Stderr, "Unknown Error Type: ", errorvalue)
+	}
+	if len(errorcode) > 0 {
+		os.Exit(errorcode[0])
+	} else {
+		os.Exit(CliGenericErrorExitCode)
+	}
+}

--- a/net/net.go
+++ b/net/net.go
@@ -45,6 +45,9 @@ func (net *Network) NewDeleteRequest(url string) *http.Request {
 func (net *Network) SendRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if resp.Status != "200 OK" {


### PR DESCRIPTION
The error_handler package provides function `ErrorExit`; the function prints
out an error message to `STDERR` and exits with a given or default exit code.
The first argument can be of type `string` or `error`.  The second argument
(optional) should be of type `integer` and is for setting the exit code.
Three integer constants are defined for setting the exit code:
- `CLIUsageErrorExitCode` - for reporting command syntax errors
- `CliGenericErrorExitCode` - for reporting processing errors
- `CLITrapErrorCode` - for reporting abnormal/trapped errors
  If the second argument is not provided the `CliGenericErrorExitCode` value is used.

The `login` command has been extended to connect to Brooklyn and obtain the version string which is then printed to `STDOUT`.
