### PR TITLE
Add 'app' and 'apps' aliases for 'application' and 'applications'

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,6 +26,7 @@ func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...comma
 func getCommand(baseName string, metadata command_metadata.CommandMetadata, runner command_runner.Runner) cli.Command {
 	command := cli.Command{
 		Name:        metadata.Name,
+		Aliases:     metadata.Aliases,
 		ShortName:   metadata.ShortName,
 		Description: metadata.Description,
 		Usage:       strings.Replace(metadata.Usage, "BROOKLYN_NAME", baseName, -1),
@@ -44,6 +45,7 @@ func getCommand(baseName string, metadata command_metadata.CommandMetadata, runn
 		for _, operand := range metadata.Operands {
 			command.Subcommands = append(command.Subcommands, cli.Command{
 				Name:            operand.Name,
+                Aliases:         operand.Aliases,
 				ShortName:       operand.ShortName,
 				Description:     operand.Description,
 				Usage:           operand.Usage,

--- a/command_metadata/command_metadata.go
+++ b/command_metadata/command_metadata.go
@@ -4,6 +4,7 @@ import "github.com/codegangsta/cli"
 
 type CommandMetadata struct {
 	Name            string
+	Aliases         []string
 	ShortName       string
 	Usage           string
 	Description     string

--- a/commands/application.go
+++ b/commands/application.go
@@ -23,6 +23,7 @@ func NewApplication(network *net.Network) (cmd *Application) {
 func (cmd *Application) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "application",
+		Aliases:     []string{"app"},
 		Description: "Show the status and location of a running application",
 		Usage:       "BROOKLYN_NAME application APP",
 		Flags:       []cli.Flag{},

--- a/commands/applications.go
+++ b/commands/applications.go
@@ -23,6 +23,7 @@ func NewApplications(network *net.Network) (cmd *Applications) {
 func (cmd *Applications) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "applications",
+		Aliases:     []string{"apps"},
 		Description: "Show the status and location of running applications",
 		Usage:       "BROOKLYN_NAME applications",
 		Flags:       []cli.Flag{},


### PR DESCRIPTION
Add 'app' and 'apps' aliases for 'application' and 'applications', respectively.

This is to bring these commands into line with the draft ref guide,
https://gist.github.com/lloyddave/c6c2287043ab12d13fa8
