### PR TITLE
Amend config command to support either all or selected config.

### DIFF
--- a/api/entity_config/config.go
+++ b/api/entity_config/config.go
@@ -7,18 +7,22 @@ import (
 	"github.com/brooklyncentral/brooklyn-cli/net"
 )
 
-func ConfigValue(network *net.Network, application, entity, config string) string {
-	return string(ConfigValueAsBytes(network, application, entity, config))
+func ConfigValue(network *net.Network, application, entity, config string) (string, error) {
+	bytes, err := ConfigValueAsBytes(network, application, entity, config)
+	if nil != err {
+		return "", err
+	}
+	return string(bytes), nil
 }
 
-func ConfigValueAsBytes(network *net.Network, application, entity, config string) []byte {
+func ConfigValueAsBytes(network *net.Network, application, entity, config string) ([]byte, error) {
 	url := fmt.Sprintf("/v1/applications/%s/entities/%s/config/%s", application, entity, config)
 	body, err := network.SendGetRequest(url)
 	if err != nil {
-		fmt.Println(err)
+		return []byte{}, err
 	}
 
-	return body
+	return body, nil
 }
 
 func SetConfig(network *net.Network, application, entity, config, value string) string {

--- a/commands/config.go
+++ b/commands/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/terminal"
 	"github.com/brooklyncentral/brooklyn-cli/scope"
+    "os"
 )
 
 type Config struct {
@@ -30,10 +31,21 @@ func (cmd *Config) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Config) Run(scope scope.Scope, c *cli.Context) {
-	config := entity_config.ConfigCurrentState(cmd.network, scope.Application, scope.Entity)
-	table := terminal.NewTable([]string{"Key", "Value"})
-	for key, value := range config {
-		table.Add(key, fmt.Sprintf("%v", value))
-	}
-	table.Print()
+
+    if c.Args().Present() {
+        config, err := entity_config.ConfigValue(cmd.network, scope.Application, scope.Entity, c.Args().First())
+        if nil != err {
+            fmt.Fprintln(os.Stderr, err)
+            os.Exit(1)
+        }
+        fmt.Println(config)
+
+    } else {
+        config := entity_config.ConfigCurrentState(cmd.network, scope.Application, scope.Entity)
+        table := terminal.NewTable([]string{"Key", "Value"})
+        for key, value := range config {
+            table.Add(key, fmt.Sprintf("%v", value))
+        }
+        table.Print()
+    }
 }


### PR DESCRIPTION
For example:

   br application testcase entity "Tomcat Server" config

will show all config values for the entity (in a table with headers), while

   br application testcase entity "Tomcat Server" config camp.plan.id

will show just the selected value (without table headers).
