### PR TITLE
Verify Brooklyn URL for command execution and login process.

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -25,15 +25,15 @@ func NewDeploy(network *net.Network) (cmd *Deploy) {
 func (cmd *Deploy) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "deploy",
-		Description: "Deploy a new brooklyn application from the supplied YAML",
-		Usage:       "BROOKLYN_NAME deploy <FILEPATH|->",
+		Description: "Deploy a new application from the given YAML (read from file or stdin)",
+		Usage:       "BROOKLYN_NAME deploy ( <FILE> | - )",
 		Flags:       []cli.Flag{},
 	}
 }
 
 func (cmd *Deploy) Run(scope scope.Scope, c *cli.Context) {
 	if c.Args().First() == "" {
-		error_handler.ErrorExit("A filename or '-' must be provided as the first argument",error_handler.CLIUsageErrorExitCode)
+		error_handler.ErrorExit("A filename or '-' must be provided as the first argument", error_handler.CLIUsageErrorExitCode)
 	}
 	if c.Args().First() == "-" {
 		blueprint, err := ioutil.ReadAll(os.Stdin)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -7,7 +7,9 @@ import (
 	"github.com/brooklyncentral/brooklyn-cli/command_metadata"
 	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/scope"
-    "github.com/brooklyncentral/brooklyn-cli/error_handler"
+	"github.com/brooklyncentral/brooklyn-cli/error_handler"
+	"io/ioutil"
+	"os"
 )
 
 type Deploy struct {
@@ -24,15 +26,30 @@ func (cmd *Deploy) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "deploy",
 		Description: "Deploy a new brooklyn application from the supplied YAML",
-		Usage:       "BROOKLYN_NAME [ SCOPE ] deploy FILEPATH",
+		Usage:       "BROOKLYN_NAME deploy <FILEPATH|->",
 		Flags:       []cli.Flag{},
 	}
 }
 
 func (cmd *Deploy) Run(scope scope.Scope, c *cli.Context) {
-	create, err := application.Create(cmd.network, c.Args().First())
-    if nil != err {
-        error_handler.ErrorExit(err)
-    }
-	fmt.Println(create)
+	if c.Args().First() == "" {
+		error_handler.ErrorExit("A filename or '-' must be provided as the first argument",error_handler.CLIUsageErrorExitCode)
+	}
+	if c.Args().First() == "-" {
+		blueprint, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			error_handler.ErrorExit(err)
+		}
+		create, err := application.CreateFromBytes(cmd.network, blueprint)
+		if nil != err {
+			error_handler.ErrorExit(err)
+		}
+		fmt.Println(create)
+	} else {
+		create, err := application.Create(cmd.network, c.Args().First())
+		if nil != err {
+			error_handler.ErrorExit(err)
+		}
+		fmt.Println(create)
+	}
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -43,6 +43,10 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 	cmd.network.BrooklynUrl = c.Args().Get(0)
 	cmd.network.BrooklynUser = c.Args().Get(1)
 	cmd.network.BrooklynPass = c.Args().Get(2)
+
+	if err := net.VerifyLoginURL(cmd.network); err != nil {
+		error_handler.ErrorExit(err)
+	}
 	
 	// Strip off trailing '/' from URL if present.
 	if cmd.network.BrooklynUrl[len(cmd.network.BrooklynUrl)-1] == '/' {

--- a/commands/version.go
+++ b/commands/version.go
@@ -5,9 +5,9 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/brooklyncentral/brooklyn-cli/api/version"
 	"github.com/brooklyncentral/brooklyn-cli/command_metadata"
+	"github.com/brooklyncentral/brooklyn-cli/error_handler"
 	"github.com/brooklyncentral/brooklyn-cli/net"
 	"github.com/brooklyncentral/brooklyn-cli/scope"
-    "github.com/brooklyncentral/brooklyn-cli/error_handler"
 )
 
 type Version struct {
@@ -30,9 +30,12 @@ func (cmd *Version) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Version) Run(scope scope.Scope, c *cli.Context) {
-	version, err := version.Version(cmd.network)
+    if err := net.VerifyLoginURL(cmd.network); err != nil {
+        error_handler.ErrorExit(err)
+    }
+    version, err := version.Version(cmd.network)
     if nil != err {
         error_handler.ErrorExit(err)
     }
-	fmt.Println(version.Version)
+    fmt.Println(version)
 }

--- a/net/net.go
+++ b/net/net.go
@@ -138,10 +138,10 @@ func VerifyLoginURL(network *Network) error {
 		return err
 	}
 	if url.Scheme != "http" && url.Scheme != "https" {
-		return errors.New("Brooklyn URL must have a scheme of \"http\" or \"https\"")
+		return errors.New("Use login command to set Brooklyn URL with a scheme of \"http\" or \"https\"")
 	}
 	if url.Host == "" {
-		return errors.New("Brooklyn URL must have a valid host")
+		return errors.New("Use login command to set Brooklyn URL with a valid host[:port]")
 	}
 	return nil
 }

--- a/net/net.go
+++ b/net/net.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,4 +130,18 @@ func (net *Network) SendPostFileRequest(url, filePath string, contentType string
 	req.Header.Set("Content-Type", contentType)
 	body, err := net.SendRequest(req)
 	return body, err
+}
+
+func VerifyLoginURL(network *Network) error {
+	url, err := url.Parse(network.BrooklynUrl)
+	if err != nil {
+		return err
+	}
+	if url.Scheme != "http" && url.Scheme != "https" {
+		return errors.New("Brooklyn URL must have a scheme of \"http\" or \"https\"")
+	}
+	if url.Host == "" {
+		return errors.New("Brooklyn URL must have a valid host")
+	}
+	return nil
 }


### PR DESCRIPTION
To be used when saving url/credentials with login command.
And then to be used for all other commands before submitting API request.

This implementation applied only to login and version.
