### PR TITLE
Improve error message on failure to deploy.

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -11,6 +11,7 @@ import (
     "github.com/brooklyncentral/brooklyn-cli/terminal"
     "io/ioutil"
 	"os"
+    "strings"
 )
 
 type Deploy struct {
@@ -39,28 +40,26 @@ func (cmd *Deploy) Run(scope scope.Scope, c *cli.Context) {
     
     var create models.TaskSummary
     var err error
+    var blueprint []byte
 	if c.Args().First() == "" {
 		error_handler.ErrorExit("A filename or '-' must be provided as the first argument", error_handler.CLIUsageErrorExitCode)
 	}
 	if c.Args().First() == "-" {
-		blueprint, err := ioutil.ReadAll(os.Stdin)
+		blueprint, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			error_handler.ErrorExit(err)
 		}
 		create, err = application.CreateFromBytes(cmd.network, blueprint)
-		if nil != err {
-			error_handler.ErrorExit(err)
-		}
 	} else {
 		create, err = application.Create(cmd.network, c.Args().First())
-		if nil != err {
-            if httpErr, ok := err.(net.HttpError); ok {
-                error_handler.ErrorExit(httpErr.Body, httpErr.Code)
-            } else {
-                error_handler.ErrorExit(err)
-            }
-		}
 	}
+    if nil != err {
+        if httpErr, ok := err.(net.HttpError); ok {
+            error_handler.ErrorExit(strings.Join([]string{httpErr.Status, httpErr.Body}, "\n"), httpErr.Code)
+        } else {
+            error_handler.ErrorExit(err)
+        }
+    }
     table := terminal.NewTable([]string{"Id:",create.EntityId})
     table.Add("Name:", create.EntityDisplayName)
     table.Add("Status:", create.CurrentStatus)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -54,7 +54,11 @@ func (cmd *Deploy) Run(scope scope.Scope, c *cli.Context) {
 	} else {
 		create, err = application.Create(cmd.network, c.Args().First())
 		if nil != err {
-			error_handler.ErrorExit(err)
+            if httpErr, ok := err.(net.HttpError); ok {
+                error_handler.ErrorExit(httpErr.Body, httpErr.Code)
+            } else {
+                error_handler.ErrorExit(err)
+            }
 		}
 	}
     table := terminal.NewTable([]string{"Id:",create.EntityId})


### PR DESCRIPTION
The changes in 9dc4e11d94 to tidy the output of deploy have the effect that
not enough information is displayed if the deploy fails. This change adds
further information to the output in this case.
