### PR TITLE
Set version and complete build script

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,7 +21,7 @@ var appConfig = configDefaults{
     Name:         os.Args[0],
     HelpName:     os.Args[0],
     Usage:        "A Brooklyn command line client application",
-    Version:      "0.0.0",
+    Version:      "0.9.0",
 }
 
 func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {


### PR DESCRIPTION
Set version to 0.9.0
Build script now uses godep to build binaries using saved third party dependencies.
Parameters changed to:

```
-A  Build for all OS/ARCH combinations
-a  Set ARCH to build for
-d  Set output directory
-h  Show help
-l  Set label text for including in filename
-o  Set OS to build for
-t  Set timestamp for including in filename
```
