### PR TITLE
Add maven pom for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ brooklyn-cli
 .idea
 *.iml
 temp_test
+target

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Toolchain
 
 You will need the following tools to build the CLI:
-- Go (min version 1.5.1), with full cross-compiler support (see https://golang.org/doc/install/source).
+- Go (min version 1.5.1), with full cross-compiler support (see https://golang.org/dl).
   On Mac, if using Homebrew, use "brew install go --with-cc-all"
 - godep (see https://github.com/tools/godep)
 
@@ -15,17 +15,45 @@ Optional:
 
 - Ensure your [$GOPATH](http://golang.org/cmd/go/#hdr-GOPATH_environment_variable) is set correctly 
   to a suitable location for your Go code.
-- git clone the CLI code into $GOPATH/src/github.com/brooklyncentral/brooklyn-cli
+- Install Brooklyn CLI and dependencies (note the "-d" parameter, which instructs Go to download the files but not
+  build the code).  
+`go get -d github.com/brooklyncentral/brooklyn-cli/br`  
+    
+    
+## A note on dependency management
+
+The CLI has a small number of dependencies, notably on codegansta/cli.  To manage the version of dependencies, the CLI
+code currently uses godep.  When contributing to the CLI it is important to be aware of the distinction.  To avoid
+potentially bringing in new versions of dependencies, use "godep go" to build the code using the dependencies
+saved in br/Godeps.  Alternatively, to bring in the latest versions of the dependencies, build with "go get", but in
+that case remember to update the dependencies of the project using "godep save" along with your commit.
 
 ## Compiling the code with Go for development purposes
 
-As Go dependendencies for godep are held in the main package directory ("br"), you need to build from that directory.
 
-- Use 
+### Using saved dependencies
+As Go dependendencies for godep are held in the main package directory ("br"), you need to build from that directory,
+using godep:
+
 ```bash
-godep go install
+cd $GOPATH/src/github.com/brooklyncentral/brooklyn-cli/br
+godep go install 
 ```
 This will build the "br" executable into $GOPATH/bin
+
+### Updating the dependencies
+
+To use the latest published versions of the dependencies simply use 
+```bash
+go get github.com/brooklyncentral/brooklyn-cli/br
+```
+
+When the code is ready to be committed, first update the saved dependencies with
+```bash
+cd $GOPATH/src/github.com/brooklyncentral/brooklyn-cli/br
+godep save
+```
+
 
 ## Building the code for release
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ This will build the "br" executable into $GOPATH/bin
 Either:
 - Use the build script in the "release" folder directly (see its usage for details), or
 - Invoke the build script via Maven with one of 
-  - mvn clean install                        build for local platform
-  - mvn -Dall clean install                  build for all supported platforms
-  - mvn -Dos=OS -Darch=ARCH clean install    build for platform with operating system OS and architecture ARCH
+  - ```mvn clean install```                                     build for all supported platforms
+  - ```mvn -Dtarget=native clean install```                     build for the current platform
+  - ```mvn -Dtarget=cross -Dos=OS -Darch=ARCH clean install```  build for platform with operating system OS and architecture ARCH
 
 This builds the requested binaries into the "target" directory, each with a file name that includes the version,
-timestamp, and architecture details, e.g. br.0.9.0.20151218-195906.linux.amd64.  To run any of these as "br" of 
-course you will need to create an alias or soft link.
+timestamp, and architecture details, e.g. br.0.9.0.20151218-195906.linux.amd64, and installs a zip file containing them
+all as a maven artifact.  To run any of these as "br" of course you will need to create an alias or soft link.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Brooklyn CLI
 
+A command line client for [Apache Brooklyn](https://brooklyn.apache.org).
+
 ## Toolchain
 
 You will need the following tools to build the CLI:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,48 @@
 # Brooklyn CLI
 
-## Compiling
+## Toolchain
 
-1. Ensure your [$GOPATH](http://golang.org/cmd/go/#hdr-GOPATH_environment_variable) is set correctly,
-   to some location where Go does its work, such as `~/gocode` .
-2. Get and build the cli source code: `go get github.com/brooklyncentral/brooklyn-cli/br`
-3. Run it from `$GOPATH/bin/br` (add `$GOPATH/bin/` to your PATH).
-4. Thereafter if you want to do code changes, 
-   link the `$GOPATH/src/github.com/brooklyncentral/brooklyn-cli`
-   with the directory where you want to keep your git repositories.
-   (TODO: clarify best practice for this, including how to combine
-   it with a Brooklyn all-projects build)
+You will need the following tools to build the CLI:
+- Go (min version 1.5.1), with full cross-compiler support (see https://golang.org/doc/install/source).
+  On Mac, if using Homebrew, use "brew install go --with-cc-all"
+- godep (see https://github.com/tools/godep)
+
+Optional:
+- Maven (used by the Brooklyn build process)
+
+
+## Build Pre-Requisites
+
+- Ensure your [$GOPATH](http://golang.org/cmd/go/#hdr-GOPATH_environment_variable) is set correctly 
+  to a suitable location for your Go code.
+- git clone the CLI code into $GOPATH/src/github.com/brooklyncentral/brooklyn-cli
+
+## Compiling the code with Go for development purposes
+
+As Go dependendencies for godep are held in the main package directory ("br"), you need to build from that directory.
+
+- Use 
+```bash
+godep go install
+```
+This will build the "br" executable into $GOPATH/bin
+
+## Building the code for release
+
+Either:
+- Use the build script in the "release" folder directly (see its usage for details), or
+- Invoke the build script via Maven with one of 
+  - mvn clean install                        build for local platform
+  - mvn -Dall clean install                  build for all supported platforms
+  - mvn -Dos=OS -Darch=ARCH clean install    build for platform with operating system OS and architecture ARCH
+
+This builds the requested binaries into the "target" directory, each with a file name that includes the version,
+timestamp, and architecture details, e.g. br.0.9.0.20151218-195906.linux.amd64.  To run any of these as "br" of 
+course you will need to create an alias or soft link.
 
 ## Running
+
+Ensure your path contains $GOPATH/bin.
 
 First, log in to your Brooklyn instance with:
 
@@ -42,7 +72,7 @@ And for help on individual commands:
      Selects an activity of an entity e.g. "br a myapp e myserver act iHG7sq1"
 
 
-# Commands
+## Commands
 
    Commands whose description begins with a "*" character are particularly experimental and likely to change in upcoming
    releases.  If not otherwise specified, "SCOPE" below means application or entity scope.  If an entity scope is not

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,38 @@
+<project name="CLI" >
+    <property name="build.script" location="${basedir}/release/build.sh"/>
+
+    <target name="all" >
+        <exec executable="${build.script}">
+            <arg value="-A"/>
+            <arg value="-t"/>
+            <arg value="-l"/>
+            <arg value="${project.version}"/>
+            <arg value="-d"/>
+            <arg value="${project.build.directory}"/>
+        </exec>
+    </target>
+
+    <target name="cross">
+        <exec executable="${build.script}">
+            <arg value="-t"/>
+            <arg value="-l"/>
+            <arg value="${project.version}"/>
+            <arg value="-a"/>
+            <arg value="${arch}"/>
+            <arg value="-o"/>
+            <arg value="${os}"/>
+            <arg value="-d"/>
+            <arg value="${project.build.directory}"/>
+        </exec>
+    </target>
+
+    <target name="native">
+        <exec executable="${build.script}">
+            <arg value="-l"/>
+            <arg value="${project.version}"/>
+            <arg value="-d"/>
+            <arg value="${project.build.directory}"/>
+        </exec>
+    </target>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,16 +39,15 @@
 
     Run as one of:
 
-    mvn clean install                     build for local platform
-    mvn -Dall clean install               build for all supported platforms
-    mvn -Dos=OS -Darch=ARCH clean all     build for platform with operating system OS and architecture ARCH
+    mvn clean install                        build for local platform
+    mvn -Dall clean install                  build for all supported platforms
+    mvn -Dos=OS -Darch=ARCH clean install    build for platform with operating system OS and architecture ARCH
 
     -->
 
     <properties>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
-        <main.dir>${basedir}/br</main.dir>
-        <build.script>${main.dir}/build.sh</build.script>
+        <build.script>${basedir}/release/build.sh</build.script>
         <os/>
         <arch/>
     </properties>
@@ -64,7 +63,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <target if="all">
-                                <exec dir="${main.dir}" executable="${build.script}">
+                                <exec executable="${build.script}">
                                     <arg value="-A"/>
                                     <arg value="-t"/>
                                     <arg value="-l"/>
@@ -83,7 +82,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <target unless="all">
-                                <exec dir="${main.dir}" executable="${build.script}">
+                                <exec executable="${build.script}">
                                     <arg value="-t"/>
                                     <arg value="-l"/>
                                     <arg value="${project.version}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>brooklyn-cli</artifactId>
     <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn-client-cli</artifactId>
     <version>0.9.0</version>
 
     <name>Brooklyn Client Command Line Interface</name>
@@ -39,17 +39,16 @@
 
     Run as one of:
 
-    mvn clean install                        build for local platform
-    mvn -Dall clean install                  build for all supported platforms
-    mvn -Dos=OS -Darch=ARCH clean install    build for platform with operating system OS and architecture ARCH
+    mvn -Dtarget=native clean install                      build for local platform
+    mvn -Dtarget=all clean install                         build for all supported platforms
+    mvn -Dtarget=cross -Dos=OS -Darch=ARCH clean install   build for platform with operating system OS and architecture ARCH
 
     -->
 
     <properties>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
-        <build.script>${basedir}/release/build.sh</build.script>
-        <os/>
-        <arch/>
+        <maven.assembly.plugin.version>2.6</maven.assembly.plugin.version>
+        <target>all</target>
     </properties>
 
     <build>
@@ -62,37 +61,8 @@
                         <id>process-build-all</id>
                         <phase>compile</phase>
                         <configuration>
-                            <target if="all">
-                                <exec executable="${build.script}">
-                                    <arg value="-A"/>
-                                    <arg value="-t"/>
-                                    <arg value="-l"/>
-                                    <arg value="${project.version}"/>
-                                    <arg value="-d"/>
-                                    <arg value="${project.build.directory}"/>
-                                </exec>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>process-build-os</id>
-                        <phase>compile</phase>
-                        <configuration>
-                            <target unless="all">
-                                <exec executable="${build.script}">
-                                    <arg value="-t"/>
-                                    <arg value="-l"/>
-                                    <arg value="${project.version}"/>
-                                    <arg value="-a"/>
-                                    <arg value="${arch}"/>
-                                    <arg value="-o"/>
-                                    <arg value="${os}"/>
-                                    <arg value="-d"/>
-                                    <arg value="${project.build.directory}"/>
-                                </exec>
+                            <target>
+                                <ant target="${target}"/>
                             </target>
                         </configuration>
                         <goals>
@@ -101,6 +71,24 @@
                     </execution>
 
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/bin.xml</descriptor>
+                    </descriptors>
+                </configuration><executions>
+                <execution>
+                    <id>make-assembly</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+
             </plugin>
         </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>brooklyn-cli</artifactId>
+    <groupId>org.apache.brooklyn</groupId>
+    <version>0.9.0</version>
+
+    <name>Brooklyn Client Command Line Interface</name>
+    <description>
+        A command line client for Apache Brooklyn
+    </description>
+
+
+    <!--
+
+    Run as one of:
+
+    mvn clean install                     build for local platform
+    mvn -Dall clean install               build for all supported platforms
+    mvn -Dos=OS -Darch=ARCH clean all     build for platform with operating system OS and architecture ARCH
+
+    -->
+
+    <properties>
+        <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
+        <main.dir>${basedir}/br</main.dir>
+        <build.script>${main.dir}/build.sh</build.script>
+        <os/>
+        <arch/>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>process-build-all</id>
+                        <phase>compile</phase>
+                        <configuration>
+                            <target if="all">
+                                <exec dir="${main.dir}" executable="${build.script}">
+                                    <arg value="-A"/>
+                                    <arg value="-t"/>
+                                    <arg value="-l"/>
+                                    <arg value="${project.version}"/>
+                                    <arg value="-d"/>
+                                    <arg value="${project.build.directory}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>process-build-os</id>
+                        <phase>compile</phase>
+                        <configuration>
+                            <target unless="all">
+                                <exec dir="${main.dir}" executable="${build.script}">
+                                    <arg value="-t"/>
+                                    <arg value="-l"/>
+                                    <arg value="${project.version}"/>
+                                    <arg value="-a"/>
+                                    <arg value="${arch}"/>
+                                    <arg value="-o"/>
+                                    <arg value="${os}"/>
+                                    <arg value="-d"/>
+                                    <arg value="${project.build.directory}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+</project>

--- a/release/build.sh
+++ b/release/build.sh
@@ -156,7 +156,7 @@ fi
 
 if [ -z "$os" -a -z "$all" ]; then
 	echo "Building $BRNAME for native OS/ARCH"
-	$GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}" $GOPACKAGE
+	$GODEP $GOBIN build -ldflags "-s" -o "${dir}/${BRNAME}${label}${timestamp}" $GOPACKAGE
 elif [ -z "$all" ]; then
 	validos=`expr " $OSVALUES " : ".* $os "`
 	if [ "$validos" -eq 0 ]; then
@@ -171,7 +171,7 @@ elif [ -z "$all" ]; then
 		exit 1
 	fi
 	echo "Building $BRNAME for $os/$arch"
-	GOOS="$os" GOARCH="$arch" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$os.$arch" $GOPACKAGE
+	GOOS="$os" GOARCH="$arch" $GODEP $GOBIN build -ldflags "-s" -o "${dir}/${BRNAME}${label}${timestamp}.$os.$arch" $GOPACKAGE
 else
 	echo "Building $BRNAME for all OS/ARCH:"
 	os="$OSVALUES"
@@ -179,7 +179,7 @@ else
 	for j in $arch; do
 		for i in $os; do
 			printf "    $i/$j \n"
-			GOOS="$i" GOARCH="$j" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$i.$j" $GOPACKAGE
+			GOOS="$i" GOARCH="$j" $GODEP $GOBIN build -ldflags "-s" -o "${dir}/${BRNAME}${label}${timestamp}.$i.$j" $GOPACKAGE
 		done
 		printf "\n"
 	done

--- a/release/build.sh
+++ b/release/build.sh
@@ -14,9 +14,8 @@
 OSVALUES="darwin freebsd linux netbsd openbsd windows"
 ARCHVALUES="386 amd64"
 BRNAME="br"
-BRFILE="brooklyn.go"
-BRDIR="brooklyn-cli/br"
-
+GOPACKAGE="github.com/brooklyncentral/brooklyn-cli/${BRNAME}"
+EXECUTABLE_DIR="$GOPATH/src/$GOPACKAGE"
 GOBIN=go
 GODEP=godep
 
@@ -147,20 +146,17 @@ if [ \( -n "$os" -a -z "$arch" \) -o \( -z "$os" -a -n "$arch" \) ]; then
 	exit 1
 fi
 
-thisdir=`pwd`
-validdir=`expr "$thisdir" : ".*${BRDIR}\$"`
-if [ "$validdir" -eq 0 ]; then
-	echo "Must be in CLI directory: $BRDIR"
-	exit 2
-fi
-if [ ! -f "$BRFILE" ]; then
-	echo "Directory must contain CLI file: $BRFILE"
+
+if [ -d ${EXECUTABLE_DIR} ]; then
+    cd ${EXECUTABLE_DIR}
+else
+	echo "Directory not found: ${EXECUTABLE_DIR}"
 	exit 2
 fi
 
 if [ -z "$os" -a -z "$all" ]; then
 	echo "Building $BRNAME for native OS/ARCH"
-	$GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}"
+	$GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}" $GOPACKAGE
 elif [ -z "$all" ]; then
 	validos=`expr " $OSVALUES " : ".* $os "`
 	if [ "$validos" -eq 0 ]; then
@@ -175,16 +171,15 @@ elif [ -z "$all" ]; then
 		exit 1
 	fi
 	echo "Building $BRNAME for $os/$arch"
-	GOOS="$os" GOARCH="$arch" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$os.$arch"
+	GOOS="$os" GOARCH="$arch" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$os.$arch" $GOPACKAGE
 else
-	echo "Building $BRNAME for common OS/ARCH:"
+	echo "Building $BRNAME for all OS/ARCH:"
 	os="$OSVALUES"
 	arch="$ARCHVALUES"
 	for j in $arch; do
-		printf "  "
 		for i in $os; do
-			printf "$i/$j "
-			GOOS="$i" GOARCH="$j" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$i.$j"
+			printf "    $i/$j \n"
+			GOOS="$i" GOARCH="$j" $GODEP $GOBIN build -o "${dir}/${BRNAME}${label}${timestamp}.$i.$j" $GOPACKAGE
 		done
 		printf "\n"
 	done

--- a/release/build.sh
+++ b/release/build.sh
@@ -178,10 +178,9 @@ else
 	arch="$ARCHVALUES"
 	for j in $arch; do
 		for i in $os; do
-			printf "    $i/$j \n"
+			echo "    $i/$j"
 			GOOS="$i" GOARCH="$j" $GODEP $GOBIN build -ldflags "-s" -o "${dir}/${BRNAME}${label}${timestamp}.$i.$j" $GOPACKAGE
 		done
-		printf "\n"
 	done
 fi
 

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -1,0 +1,30 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>bin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+                <include>NOTICE*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>br.*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/site</directory>
+            <outputDirectory>docs</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -8,7 +8,6 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}</directory>
-            <outputDirectory>/</outputDirectory>
             <includes>
                 <include>README*</include>
                 <include>LICENSE*</include>
@@ -17,14 +16,9 @@
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>/</outputDirectory>
             <includes>
                 <include>br.*</include>
             </includes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/site</directory>
-            <outputDirectory>docs</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
This adds a maven pom.xml so that the project can be conveniently incorporated into an overall Maven build.  It assumes the toolchain exists, i.e. you have Go and Godep already set up.

You can invoke Maven as any of 
- `mvn clean install`                                     build for all supported platforms
- `mvn -Dtarget=native clean install`                     build for the current platform
- `mvn -Dtarget=cross -Dos=OS -Darch=ARCH clean install`  build for platform with operating system OS and architecture ARCH

where the supported OSes are any of darwin freebsd linux netbsd openbsd windows, and the architectures are either 386 or amd64.

The maven artefact is a zip file containing all the built binaries.
